### PR TITLE
Fix ZeroDivisionError being raised

### DIFF
--- a/sx/pisa3/pisa_reportlab.py
+++ b/sx/pisa3/pisa_reportlab.py
@@ -631,6 +631,7 @@ class PmlKeepInFrame(KeepInFrame, PmlMaxHeightMixIn):
 
     def wrap(self, availWidth, availHeight):
         availWidth = max(availWidth, 1.0)
+        availHeight = max(availHeight, 1.0)
         self.maxWidth = availWidth
         self.maxHeight = self.setMaxHeight(availHeight)
         return KeepInFrame.wrap(self, availWidth, availHeight)


### PR DESCRIPTION
While debugging DO-3438, saw this occur when generating a PDF. When running test related to the issue, all of them past with this code change, so I think it will be OK to push.

```
Traceback (most recent call last):
  File ".../pisa/sx/pisa3/pisa_document.py", line 172, in pisaDocument
    doc.build(c.story)
  File ".../reportlab/platypus/doctemplate.py", line 1036, in build
    self.handle_flowable(flowables)
  File ".../reportlab/platypus/doctemplate.py", line 892, in handle_flowable
    if frame.add(f, canv, trySplit=self.allowSplitting):
  File ".../reportlab/platypus/frames.py", line 217, in _add
    flowable.drawOn(canv, self._x + self._leftExtraIndent, y, _sW=aW-w)
  File ".../reportlab/platypus/flowables.py", line 113, in drawOn
    self._drawOn(canvas)
  File ".../reportlab/platypus/flowables.py", line 94, in _drawOn
    self.draw()#this is the bit you overload
  File "..../reportlab/platypus/tables.py", line 1457, in draw
    self._drawCell(cellval, cellstyle, (colpos, rowpos), (colwidth, rowheight))
  File ".../reportlab/platypus/tables.py", line 1574, in _drawCell
    w, h = self._listCellGeom(cellval,colwidth,cellstyle,W=W, H=H,aH=rowheight)
  File ".../pisa/sx/pisa3/pisa_reportlab.py", line 652, in _listCellGeom
    return Table._listCellGeom(self, V, w, s, W=W, H=H, aH=aH)
  File ".../reportlab/platypus/tables.py", line 417, in _listCellGeom
    vw, vh = v.wrapOn(canv, aW, aH)
  File ".../reportlab/platypus/flowables.py", line 124, in wrapOn
    w, h = self.wrap(aW,aH)
  File ".../pisa/sx/pisa3/pisa_reportlab.py", line 636, in wrap
    return KeepInFrame.wrap(self, availWidth, availHeight)
  File ".../reportlab/platypus/flowables.py", line 1172, in wrap
    W, H = func(s1)
  File ".../reportlab/platypus/flowables.py", line 1153, in func
    W /= x
ZeroDivisionError: float division by zero
```