### PR TITLE
[DA-5427] Return only the integer portion of the wrapped object's height and width

### DIFF
--- a/sx/pisa3/pisa_reportlab.py
+++ b/sx/pisa3/pisa_reportlab.py
@@ -634,7 +634,14 @@ class PmlKeepInFrame(KeepInFrame, PmlMaxHeightMixIn):
         availHeight = max(availHeight, 1.0)
         self.maxWidth = availWidth
         self.maxHeight = self.setMaxHeight(availHeight)
-        return KeepInFrame.wrap(self, availWidth, availHeight)
+        # I could probably just return the list comprehension and let the
+        # calling code dereference on the outside, especially since this just
+        # returns a tuple, but I prefer to be explicit. Makes it easier to
+        # find bugs.
+        cur_height, cur_weight = [
+            int(v) for v in KeepInFrame.wrap(self, availWidth, availHeight)
+        ]
+        return cur_height, cur_weight
 
 class PmlTable(Table, PmlMaxHeightMixIn):
 


### PR DESCRIPTION
This resolves a problem in Pisa where occasionally scaled-down tables are a fraction of a pixel too large for their containers. See [DA-5427](https://drchrono.atlassian.net/browse/DA-5427) on Jira.