### PR TITLE
[DA-5443] Remove NotImplemented and None from list

### DIFF
--- a/sx/pisa3/pisa_parser.py
+++ b/sx/pisa3/pisa_parser.py
@@ -279,7 +279,7 @@ def CSS2Frag(c, kw, isBlock):
             c.frag.bold = 1
         else:
             c.frag.bold = 0
-    for value in toList(c.cssAttr.get("text-decoration", "")):
+    for value in [val for val in toList(c.cssAttr.get("text-decoration", "")) if (val is not NotImplemented and val is not None)]:
         if "underline" in value:
             c.frag.underline = 1
         if "line-through" in value:


### PR DESCRIPTION
We've occasionally been seeing [this error](https://sentry.drchrono.dev/organizations/drchrono/issues/17767/events/96f7afdfd4a3436b9dd04b673dafc2ae/?project=2&statsPeriod=14d) in rendering, which happens when a function somewhere else returns `NotImplemented` instead of the value we expect for a `text-decoration` CSS attribute. I'm still not 100% sure where this deeper error is occurring because I only have the one error and the traceback doesn't go any deeper, but this *should* solve the problem and render a PDF.